### PR TITLE
Fix: add missing fields in action.yml, and pick unique name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,5 @@
-name: 'Flake8'
+name: 'Flake8 with annotations'
+author: 'Patric "TrueBrain" Stout'
 description: 'Flake8 with annotations for Pull Request'
 inputs:
   path:
@@ -12,3 +13,6 @@ inputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
+branding:
+  icon: 'code'
+  color: 'blue'


### PR DESCRIPTION
While publishing on Marketplace, GitHub indicated several missing
fields, and that the name was not unique within the population.