### PR TITLE
Doc: Use "@v1" instead of "@master" as the latter might break from time to time

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Any warnings or errors will be annotated in the Pull Request.
 ## Usage
 
 ```
-uses: TrueBrain/actions-flake8@master
+uses: TrueBrain/actions-flake8@v1
 ```
 
 ### Parameter: path
@@ -21,7 +21,7 @@ This can be useful if your project is more than Python code.
 This parameter is optional; by default `flake8` will run on your whole repository.
 
 ```
-uses: TrueBrain/actions-flake8@master
+uses: TrueBrain/actions-flake8@v1
 with:
   path: src
 ```
@@ -33,7 +33,7 @@ Indicates errors and warnings to skip.
 This parameter is optional; by default no alerts will be ignored
 
 ```
-uses: TrueBrain/actions-flake8@master
+uses: TrueBrain/actions-flake8@v1
 with:
   ignore: E4,W
 ```
@@ -46,7 +46,7 @@ Indicates the maximum allowed line length.
 This parameter is optional; by default flake8's default line length will be used.
 
 ```
-uses: TrueBrain/actions-flake8@master
+uses: TrueBrain/actions-flake8@v1
 with:
   max_line_length: 90
 ```
@@ -61,7 +61,7 @@ All errors and warnings are annotated in Pull Requests, but it will act like eve
 This parameter is optional; setting this to any value will enable it.
 
 ```
-uses: TrueBrain/actions-flake8@master
+uses: TrueBrain/actions-flake8@v1
 with:
   only_warn: 1
 ```


### PR DESCRIPTION
It is common in GitHub Actions to have a tag that is renewed for every new release, for the first version called "v1".

This allows us to add changes to master, without every user of this action immediately picking it up. Only on a new release, the tag is renewed, and all users pick up on the changes.