### PR TITLE
Change: [GitHub] switch default branch to "main"

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,7 +3,7 @@ name: Testing
 on:
   pull_request:
     branches:
-    - master
+    - main
 
 jobs:
   run_action_warnings:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Flake8 with GitHub Actions -- including annotations for Pull Requests
 
-[![GitHub License](https://img.shields.io/github/license/TrueBrain/actions-flake8)](https://github.com/TrueBrain/actions-flake8/blob/master/LICENSE)
+[![GitHub License](https://img.shields.io/github/license/TrueBrain/actions-flake8)](https://github.com/TrueBrain/actions-flake8/blob/main/LICENSE)
 [![GitHub Tag](https://img.shields.io/github/v/tag/TrueBrain/actions-flake8?include_prereleases&label=stable)](https://github.com/TrueBrain/actions-flake8/releases)
-[![GitHub commits since latest release](https://img.shields.io/github/commits-since/TrueBrain/actions-flake8/latest/master)](https://github.com/TrueBrain/actions-flake8/commits/master)
+[![GitHub commits since latest release](https://img.shields.io/github/commits-since/TrueBrain/actions-flake8/latest/main)](https://github.com/TrueBrain/actions-flake8/commits/main)
 
 This GitHub Actions runs flake8 over your code.
 Any warnings or errors will be annotated in the Pull Request.


### PR DESCRIPTION
Although the default is now "main", I also left a copy of v1.6 as "master", to ensure those people that were using `@master` are not having a really bad day.
It sadly also means they won't be receiving any updates, but there is a limit to what I can do to broadcast this change.