### PR TITLE
Feature: allow specifying which flake8 version to use by default

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -31,10 +31,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: pip install flake8
+    - run: pip install flake8==3.8.0
     - uses: ./
       with:
         path: example_valid
+
+  run_action_valid_flake8_version:
+    name: Test run action (valid with Flake 3.8.0)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./
+      with:
+        path: example_valid
+        flake8_version: 3.8.0
 
   run_action_valid_py39:
     name: Test run action (valid with Python 3.9)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Any warnings or errors will be annotated in the Pull Request.
 ## Usage
 
 ```
-uses: TrueBrain/actions-flake8@v2
+steps:
+- uses: actions/checkout@v2
+- uses: TrueBrain/actions-flake8@v2
 ```
 
 By default it uses the default Python version as installed on the GitHub Runner.
@@ -18,13 +20,40 @@ By default it uses the default Python version as installed on the GitHub Runner.
 ### Different Python version
 
 ```
-uses: actions/setup-python@v2
-with:
-  python-version: 3.9
-uses: TrueBrain/actions-flake8@v2
-with:
-  path: src
+steps:
+- uses: actions/checkout@v2
+- uses: actions/setup-python@v2
+  with:
+    python-version: 3.9
+- uses: TrueBrain/actions-flake8@v2
+  with:
+    path: src
 ```
+
+### Parameter: flake8_version
+
+In some cases you might want to pin a certain flake8 version.
+
+This parameter is optional; by default the latest flake8 will be installed (if no flake8 is installed yet).
+
+```
+steps:
+- uses: actions/checkout@v2
+- uses: TrueBrain/actions-flake8@v2
+  with:
+    flake8_version: 3.8.0
+```
+
+Alternatively, you can pre-install flake8 before executing this action:
+
+```
+steps:
+- uses: actions/checkout@v2
+- run: pip install flake8==3.8.0
+- uses: TrueBrain/actions-flake8@v2
+```
+
+If needed, this also allows you to install other flake8-plugins.
 
 ### Parameter: path
 
@@ -34,9 +63,11 @@ This can be useful if your project is more than Python code.
 This parameter is optional; by default `flake8` will run on your whole repository.
 
 ```
-uses: TrueBrain/actions-flake8@v2
-with:
-  path: src
+steps:
+- uses: actions/checkout@v2
+- uses: TrueBrain/actions-flake8@v2
+  with:
+    path: src
 ```
 
 ### Parameter: ignore
@@ -46,9 +77,11 @@ Indicates errors and warnings to skip.
 This parameter is optional; by default no alerts will be ignored
 
 ```
-uses: TrueBrain/actions-flake8@v2
-with:
-  ignore: E4,W
+steps:
+- uses: actions/checkout@v2
+- uses: TrueBrain/actions-flake8@v2
+  with:
+    ignore: E4,W
 ```
 
 
@@ -59,9 +92,11 @@ Indicates the maximum allowed line length.
 This parameter is optional; by default flake8's default line length will be used.
 
 ```
-uses: TrueBrain/actions-flake8@v2
-with:
-  max_line_length: 90
+steps:
+- uses: actions/checkout@v2
+- uses: TrueBrain/actions-flake8@v2
+  with:
+    max_line_length: 90
 ```
 
 
@@ -74,7 +109,9 @@ All errors and warnings are annotated in Pull Requests, but it will act like eve
 This parameter is optional; setting this to any value will enable it.
 
 ```
-uses: TrueBrain/actions-flake8@v2
-with:
-  only_warn: 1
+steps:
+- uses: actions/checkout@v2
+- uses: TrueBrain/actions-flake8@v2
+  with:
+    only_warn: 1
 ```

--- a/action.yml
+++ b/action.yml
@@ -18,10 +18,20 @@ inputs:
     description: 'If set, only warn, never error'
     required: false
     default: ''
+  flake8_version:
+    description: 'What flake8 version to use, if none is installed (default is latest)'
+    required: false
+    default: ''
 runs:
   using: 'composite'
   steps:
-  - run: pip show -q flake8 || pip install flake8
+  - run: |
+      if [ -z "${{ inputs.flake8_version }}" ]; then
+        flake8_version=""
+      else
+        flake8_version="==${{ inputs.flake8_version }}"
+      fi
+      pip show -q flake8 || pip install flake8${flake8_version}
     shell: bash
   - run: ${{ github.action_path }}/action/entrypoint.sh
     shell: bash
@@ -30,6 +40,7 @@ runs:
       INPUT_IGNORE: ${{ inputs.ignore }}
       INPUT_MAX_LINE_LENGTH: ${{ inputs.max_line_length }}
       INPUT_ONLY_WARN: ${{ inputs.only_warn }}
+      INPUT_FLAKE8_VERSION: ${{ inputs.flake8_version }}
 branding:
   icon: 'code'
   color: 'blue'


### PR DESCRIPTION
This action used to be version-pinned on flake8. But in practice this is most often unwanted, and you just want the latest of flake8.

However, there are use-cases you want it pinned. So allow for this by adding another parameter for you to indicate what flake8 version you want.